### PR TITLE
Version 1.0 hotfix

### DIFF
--- a/backend/src/API/database/database.sql
+++ b/backend/src/API/database/database.sql
@@ -320,7 +320,8 @@ ALTER TABLE `reviews`
 --
 -- Indices de la tabla `sent_emails`
 --
-
+ALTER TABLE `sent_emails`
+  ADD PRIMARY KEY (`id`)
 --
 -- Indices de la tabla `tags`
 --

--- a/backend/src/API/database/database.sql
+++ b/backend/src/API/database/database.sql
@@ -321,7 +321,7 @@ ALTER TABLE `reviews`
 -- Indices de la tabla `sent_emails`
 --
 ALTER TABLE `sent_emails`
-  ADD PRIMARY KEY (`id`)
+  ADD PRIMARY KEY (`id`);
 --
 -- Indices de la tabla `tags`
 --
@@ -363,88 +363,21 @@ ALTER TABLE `user_tags`
 --
 
 --
--- AUTO_INCREMENT de la tabla `applicants`
---
-ALTER TABLE `applicants`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+ALTER TABLE applicants MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE languages MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE notifications MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE offers MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE offer_languages MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE offer_tags MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE reports MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE reviews MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE sent_emails MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE tags MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE users MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE user_following MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE user_languages MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
+ALTER TABLE user_tags MODIFY COLUMN id INT NOT NULL AUTO_INCREMENT;
 
---
--- AUTO_INCREMENT de la tabla `languages`
---
-ALTER TABLE `languages`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=7;
-
---
--- AUTO_INCREMENT de la tabla `notifications`
---
-ALTER TABLE `notifications`
-  MODIFY `id` bigint(20) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `offers`
---
-ALTER TABLE `offers`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `offer_languages`
---
-ALTER TABLE `offer_languages`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `offer_tags`
---
-ALTER TABLE `offer_tags`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `reports`
---
-ALTER TABLE `reports`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `reviews`
---
-ALTER TABLE `reviews`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `sent_emails`
---
-ALTER TABLE `sent_emails`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `tags`
---
-ALTER TABLE `tags`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=26;
-
---
--- AUTO_INCREMENT de la tabla `users`
---
-ALTER TABLE `users`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `user_following`
---
-ALTER TABLE `user_following`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `user_languages`
---
-ALTER TABLE `user_languages`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
-
---
--- AUTO_INCREMENT de la tabla `user_tags`
---
-ALTER TABLE `user_tags`
-  MODIFY `id` int(10) NOT NULL AUTO_INCREMENT;
 
 --
 -- Restricciones para tablas volcadas

--- a/backend/src/API/database/database.sql
+++ b/backend/src/API/database/database.sql
@@ -146,8 +146,8 @@ CREATE TABLE `sent_emails` (
   `id` int(10) NOT NULL,
   `subject` text NOT NULL,
   `message` text NOT NULL,
-  `sender_id` int(10) NOT NULL,
-  `receiver_id` int(10) NOT NULL,
+  `sender_email` text NOT NULL,
+  `receiver_email` text NOT NULL,
   `sent_date` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
@@ -320,10 +320,6 @@ ALTER TABLE `reviews`
 --
 -- Indices de la tabla `sent_emails`
 --
-ALTER TABLE `sent_emails`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `mail_emisor` (`sender_id`),
-  ADD KEY `mail_receptor` (`receiver_id`);
 
 --
 -- Indices de la tabla `tags`
@@ -502,9 +498,6 @@ ALTER TABLE `reviews`
 --
 -- Filtros para la tabla `sent_emails`
 --
-ALTER TABLE `sent_emails`
-  ADD CONSTRAINT `mails_enviados_ibfk_1` FOREIGN KEY (`sender_id`) REFERENCES `users` (`id`),
-  ADD CONSTRAINT `mails_enviados_ibfk_2` FOREIGN KEY (`receiver_id`) REFERENCES `users` (`id`);
 
 --
 -- Filtros para la tabla `user_following`

--- a/backend/src/API/requests/admin/accept-new-user.php
+++ b/backend/src/API/requests/admin/accept-new-user.php
@@ -27,36 +27,20 @@ require_once __DIR__ . "/../../logic/communications/return_response.php";
 require_once __DIR__ . '/../../logic/security/is_admin.php';
 require_once __DIR__ . '/../../logic/notifications/send_notification.php';
 
-if ($_SERVER['REQUEST_METHOD'] !== 'PUT') {
-    return_response("failed", "Method not allowed", null);
-    exit;
-}
+if ($_SERVER['REQUEST_METHOD'] !== 'PUT') return_response("failed", "Method not allowed", null);
 
 $data = json_decode(file_get_contents("php://input"));
-if (!$data || !isset($data->target_user_id)) {
-    return_response("failed", "Falta el ID del usuario a aceptar", null);
-    exit;
-}
+if (!$data || !isset($data->target_user_id)) return_response("failed", "Falta el ID del usuario a aceptar", null);
 
 $target_user_id = intval($data->target_user_id);
-if ($target_user_id <= 0) {
-    return_response("failed", "ID de usuario a aceptar inválido.", null);
-    exit;
-}
+if ($target_user_id <= 0) return_response("failed", "ID de usuario a aceptar inválido.", null);
 
 // Obtener el usuario autenticado desde la sesión
-if (!isset($_SESSION['user']['id'])) {
-    return_response("failed", "No autenticado.", null);
-    exit;
-}
+if (!isset($_SESSION['user']['id'])) return_response("failed", "No autenticado.", null);
 $auth_user_id = $_SESSION['user']['id'];
 
 // Verificar si el usuario autenticado es admin
-if (!is_admin($auth_user_id, $connection)) {
-    return_response("failed", "Solo los administradores pueden aceptar usuarios.", null);
-    exit;
-}
-
+if (!is_admin($auth_user_id, $connection)) return_response("failed", "Solo los administradores pueden aceptar usuarios.", null);
 // Aceptar al usuario destino
 try {
     // 1. Get the user's email and name first
@@ -101,6 +85,5 @@ try {
     }
 } catch(PDOException $e) {
     return_response("failed", "Error al aceptar el usuario.", null);
-    exit;
 }
 ?>

--- a/backend/src/API/requests/admin/reject-new-user.php
+++ b/backend/src/API/requests/admin/reject-new-user.php
@@ -71,17 +71,18 @@ try {
         exit;
     }
 
-    
+    if($target_user_type != 1){
+        // 3. Delete user-specific data if not an admin
+        $connection->exec("DELETE FROM user_languages WHERE user_id = $target_user_id");
+        $connection->exec("DELETE FROM user_tags WHERE user_id = $target_user_id");
+        $connection->exec("DELETE FROM sent_emails WHERE receiver_id = $target_user_id");
+    }
     // 2. Delete or disable the user
     $stmt = $connection->prepare("DELETE FROM users WHERE id = :id"); // or UPDATE users SET enabled = 0 WHERE id = :id
     $stmt->bindParam(':id', $target_user_id, PDO::PARAM_INT);
     $stmt->execute();
 
-    if($target_user_type != 1){
-        // 3. Delete user-specific data if not an admin
-        $connection->exec("DELETE FROM user_languages WHERE user_id = $target_user_id");
-        $connection->exec("DELETE FROM user_tags WHERE user_id = $target_user_id");
-    }
+
 
     if ($stmt->rowCount() > 0) {
         // 3. Send the email after successful delete/disable
@@ -107,7 +108,7 @@ try {
         return_response("failed", "No se pudo rechazar al usuario.", null);
     }
 } catch(PDOException $e) {
-    return_response("failed", "Error al rechazar el usuario.", null);
+    return_response("failed", "Error al rechazar el usuario." . $e->getMessage(), null);
     exit;
 }
 ?>

--- a/backend/src/API/requests/session/user-register.php
+++ b/backend/src/API/requests/session/user-register.php
@@ -128,22 +128,6 @@ try {
     $user = $stmt->fetch();
     log_debug('User fetched for session: ' . json_encode($user));
 
-    // Store user in session (auto-login after registration)
-    $_SESSION['user'] = [
-        "id" => $user["id"],
-        "name" => $user["name"],
-        "age" => $user["birth_date"],
-        "location" => $user["location"],
-        "email" => $user["email"],
-        "description" => $user["description"],
-        "last_active_date" => $user["last_active_date"],
-        "profile_picture" => $user["profile_picture"],
-        "portfolio" => $user["portfolio"],
-        "is_enabled" => $user["enabled"],
-        "type_id" => $user["user_type"],
-        "status" => $user["status"]
-    ];
-
     return_response("success", "Usuario registrado correctamente. Debe esperar aprobación.", null);
 } catch (Exception $e) {
 /*     $connection->rollBack();

--- a/backend/src/API/requests/session/user-register.php
+++ b/backend/src/API/requests/session/user-register.php
@@ -113,8 +113,8 @@ try {
     // Log the sent email in the database
     $currentDatetime = date('Y-m-d H:i:s');
     $stmt = $connection->prepare("INSERT INTO sent_emails (subject, message, sender_id, receiver_id, sent_date) VALUES (?, ?, ?, ?, ?)");
-    $email_sender = 1; // System/admin user ID
-    $stmt->execute([$email_subject, $email_message, $email_sender, $user_id, $currentDatetime]);
+    $email_sender = "admin@admin.com"; // System/admin user ID
+    $stmt->execute([$email_subject, $email_message, $email_sender, $user_email, $currentDatetime]);
     error_log('Sent email logged in DB');
 
     // Retrieve the newly created user for response

--- a/backend/src/API/requests/session/user-register.php
+++ b/backend/src/API/requests/session/user-register.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../../logic/security/security_functions.php';
 if ($_SERVER["REQUEST_METHOD"] !== "POST") return_response("failed", "Metodo no permitido.", null);
 
 $data = json_decode(file_get_contents("php://input"));
-if (!isset($data->email) || !isset($data->password) || $data -> user_type===0 || $data -> status_id===0)  return_response("failed", "Faltan datos.", null);
+if (!isset($data->email) || !isset($data->password) || $data -> user_type===0 )  return_response("failed", "Faltan datos.", null);
 
 // Assign request body values to variables
 $name = $data->name ?? null;
@@ -47,21 +47,16 @@ $knownLanguagesWithLevels = $data->languages_levels ?? [];
 $user_tags = $data->tags ?? [];
 $tags_levels = $data->tags_levels ?? [];
 
-// Logging helper
-function log_debug($msg) {
-    file_put_contents(__DIR__ . '/../../debug_user_register.log', date('Y-m-d H:i:s') . " | " . $msg . "\n", FILE_APPEND);
-}
-
-log_debug('Request received: ' . json_encode($data));
+error_log('Request received: ' . json_encode($data));
 try {
     $connection->beginTransaction();
-    log_debug('Transaction started');
+    error_log('Transaction started');
 
     // Check for duplicate email
     $stmt = $connection->prepare("SELECT email FROM users WHERE email = ?");
     $stmt->execute([$user_email]);
     if ($stmt->fetch()) {
-        log_debug('Duplicate email: ' . $user_email);
+        error_log('Duplicate email: ' . $user_email);
         return_response("failed", "El correo ya existe.", null);
     }
 
@@ -75,7 +70,7 @@ try {
         $user_last_update_date, $user_profile_picture, $user_portfolio, $user_is_enabled, $user_rol, $user_status
     ]);
     $user_id = $connection->lastInsertId();
-    log_debug('User inserted with ID: ' . $user_id);
+    error_log('User inserted with ID: ' . $user_id);
     if ($user_rol !== 1) {
         // Insert user languages
         if (!empty($user_languages) && !empty($knownLanguagesWithLevels)) {
@@ -84,7 +79,7 @@ try {
                 $level_id = $knownLanguagesWithLevels[$i] ?? null;
                 if ($level_id !== null) {
                     $stmt->execute([$user_id, $lang_id, $level_id]);
-                    log_debug("Inserted user_language: user_id=$user_id, lang_id=$lang_id, level_id=$level_id");
+                    error_log("Inserted user_language: user_id=$user_id, lang_id=$lang_id, level_id=$level_id");
                 }
             }
         }
@@ -96,7 +91,7 @@ try {
                 $level_id = $tags_levels[$i] ?? null;
                 if ($level_id !== null) {
                     $stmt->execute([$user_id, $tag_id, $level_id]);
-                    log_debug("Inserted user_tag: user_id=$user_id, tag_id=$tag_id, level_id=$level_id");
+                    error_log("Inserted user_tag: user_id=$user_id, tag_id=$tag_id, level_id=$level_id");
                 }
             }
         }
@@ -105,14 +100,14 @@ try {
 
     // Commit transaction
     $connection->commit();
-    log_debug('Transaction committed');
+    error_log('Transaction committed');
 
     // Send confirmation email (server-side, secure)
     require_once __DIR__ . '/../../logic/communications/send_email.php';
     $email_subject = 'Registro en espera';
     $email_message = '¡Hola!, tu registro se ha cargado con éxito, debe esperar a que un administrador acepte su solicitud para poder utilizar nuestro software. Ten paciencia.<br><br>Gracias por registrarte en UNITEC.';
     $send_result = send_email($user_email, $email_subject, $email_message);
-    log_debug('Email sent: ' . ($send_result ? 'OK' : 'FAILED'));
+    error_log('Email sent: ' . ($send_result ? 'OK' : 'FAILED'));
     if (!$send_result) error_log("Failed to send registration email to $user_email");
 
     // Log the sent email in the database
@@ -120,18 +115,18 @@ try {
     $stmt = $connection->prepare("INSERT INTO sent_emails (subject, message, sender_id, receiver_id, sent_date) VALUES (?, ?, ?, ?, ?)");
     $email_sender = 1; // System/admin user ID
     $stmt->execute([$email_subject, $email_message, $email_sender, $user_id, $currentDatetime]);
-    log_debug('Sent email logged in DB');
+    error_log('Sent email logged in DB');
 
     // Retrieve the newly created user for response
     $stmt = $connection->prepare("SELECT * FROM users WHERE id = ?");
     $stmt->execute([$user_id]);
     $user = $stmt->fetch();
-    log_debug('User fetched for session: ' . json_encode($user));
+    error_log('User fetched for session: ' . json_encode($user));
 
     return_response("success", "Usuario registrado correctamente. Debe esperar aprobación.", null);
 } catch (Exception $e) {
 /*     $connection->rollBack();
-    log_debug('Transaction rolled back'); */
+    error_log('Transaction rolled back'); */
     error_log('Exception: ' . $e->getMessage());
     return_response("failed", "Ocurrió un error: No se pudo registrar al usuario" );
 }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
       - VITE_API_URL_DEV=http://localhost:9090/src/API/requests
       - VITE_API_URL_PROD=http://localhost:9090/src/API/requests
     ports:
-      - "10000:5173"
+      - "5174:5173"
     profiles: ["dev"]
 
   backend:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -29,5 +29,5 @@ services:
       - DB_PASS_DEV=${DB_PASS_DEV}
       - DB_PORT_DEV=${DB_PORT_DEV}
     ports:
-      - "10001:80"
+      - "9090:80"
     profiles: ["dev"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,9 @@ server {
   root /usr/share/nginx/html;
   index index.html;
   location /UNiTEC/ {
+    if (!-e $request_filename){
+      rewrite ^(.*)$ /UNiTEC/index.html break;
+    }
     try_files $uri $uri/ /index.html;
   }
   location /UNiTEC/assets/ {

--- a/frontend/src/components/session/RegisterEnterprise.tsx
+++ b/frontend/src/components/session/RegisterEnterprise.tsx
@@ -203,7 +203,7 @@ const RegisterEnterprise: React.FC = () => {
                         event.preventDefault();
                         const form = document.getElementById("register-enterprise") as HTMLFormElement;
                         if (form) form.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-                        navigate('/');
+
                     }}/>
                     {error}
                     <div className="delimiter"></div>

--- a/frontend/src/components/session/RegisterEnterprise.tsx
+++ b/frontend/src/components/session/RegisterEnterprise.tsx
@@ -203,6 +203,7 @@ const RegisterEnterprise: React.FC = () => {
                         event.preventDefault();
                         const form = document.getElementById("register-enterprise") as HTMLFormElement;
                         if (form) form.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+                        navigate('/');
                     }}/>
                     {error}
                     <div className="delimiter"></div>


### PR DESCRIPTION
Basically in the register after succes, it saved the user in session. Because the user needs to be accepted first this was a terrible logic problem but it didnt trigger, we dont know why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Registration no longer creates an active session after sign-up; users must log in separately.
  - Admin removal now cleans up related user data before deletion.

- **User Experience**
  - Rejection flow sends notification emails to rejected applicants.
  - Error responses include more context; registration failures won’t leave a session.

- **Deployment/Hosting**
  - Requests under /UNiTEC/ that don't match a file serve /UNiTEC/index.html.
  - Local dev port mappings for frontend/backend updated.

- **Database**
  - Sent-emails now record email addresses instead of user IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->